### PR TITLE
fix(timer): BlynkTimer Broken on Low Memory Ports

### DIFF
--- a/TIMERS.md
+++ b/TIMERS.md
@@ -66,7 +66,10 @@ print(blynk_timer.get_timers())
 
 # switch timer state to stopped by timer id
 # id = order_num + '_' + function_name
+# OR: on ports with low memory (such as the esp8266)
+# id = order_num + '_' + 'timer'
 blynk_timer.stop('2_function2')
+
 
 while True:
     intervals = blynk_timer.run()

--- a/blynktimer.py
+++ b/blynktimer.py
@@ -44,8 +44,11 @@ class Timer(object):
         self.no_timers_err = no_timers_err
 
     def _get_func_name(self, obj):
+        """retrieves a suitable name for a function"""
         if hasattr(obj, 'func'):
+            # handles nested decorators
             return self._get_func_name(obj.func)
+        # simply returns 'timer' if on port without function attrs
         return getattr(obj, '__name__', 'timer')
 
     def register(blynk, *args, interval=DEFAULT_INTERVAL, run_once=False, **kwargs):

--- a/blynktimer.py
+++ b/blynktimer.py
@@ -44,11 +44,9 @@ class Timer(object):
         self.no_timers_err = no_timers_err
 
     def _get_func_name(self, obj):
-        if not hasattr(obj, '__name__'):
-            if hasattr(obj, 'func'):
-                return self._get_func_name(obj.func)
-            return 'timer'
-        return obj.__name__
+        if hasattr(obj, 'func'):
+            return self._get_func_name(obj.func)
+        return getattr(obj, '__name__', 'timer')
 
     def register(blynk, *args, interval=DEFAULT_INTERVAL, run_once=False, **kwargs):
         class Deco(object):

--- a/blynktimer.py
+++ b/blynktimer.py
@@ -44,8 +44,10 @@ class Timer(object):
         self.no_timers_err = no_timers_err
 
     def _get_func_name(self, obj):
-        if getattr(obj, '__name__', None) is None:
-            return self._get_func_name(obj.func)
+        if not hasattr(obj, '__name__'):
+            if hasattr(obj, 'func'):
+                return self._get_func_name(obj.func)
+            return 'timer'
         return obj.__name__
 
     def register(blynk, *args, interval=DEFAULT_INTERVAL, run_once=False, **kwargs):


### PR DESCRIPTION
Fixes #5 

## Notes
On most low memory ports (such as the esp8266) the config variable [`MICROPY_PY_FUNCTION_ATTRS`](https://github.com/micropython/micropython/blob/34c04d2319cdfae01ed7bf7f9e341d69b86d751a/py/mpconfig.h#L774) is disabled, effectively meaning `func.__name__` doesn't exist. (See [micropython/micropython#614](https://github.com/micropython/micropython/issues/614) for more details)

Because `Timer` relies on `func.__name__` to name its timers, its effectively broken on any port without `MICROPY_PY_FUNCTION_ATTRS` enabled. 

## Changes
This PR fixes this issue by doing the following:
* Checks if `func.__name__` exists
* If yes, continues as normal
* If not:
   - Check if `obj.func` exists and reattempt with that (original fallback)
   - If not, then simply return "timer"

* Also adds a note in `TIMERS.md` referring to this change.

This essentially means that on ports without `MICROPY_PY_FUNCTION_ATTRS`, timers are named `X_timer`, with X as the original number of timer.