### PR TITLE
test(wildcard): Updated Wildcard Tests to include V0

### DIFF
--- a/blynklib.py
+++ b/blynklib.py
@@ -308,7 +308,7 @@ class Blynk(Connection):
                 # wildcard 'read V*' and 'write V*' events handling
                 if str(event_name).lower() in (blynk._VPIN_READ_ALL, blynk._VPIN_WRITE_ALL):
                     event_base_name = str(event_name).split(blynk._VPIN_WILDCARD)[0]
-                    for i in range(blynk.VPIN_MAX_NUM):
+                    for i in range(blynk.VPIN_MAX_NUM + 1):
                         blynk._events['{}{}'.format(event_base_name.lower(), i)] = func
                 else:
                     blynk._events[str(event_name).lower()] = func

--- a/blynklib.py
+++ b/blynklib.py
@@ -308,7 +308,7 @@ class Blynk(Connection):
                 # wildcard 'read V*' and 'write V*' events handling
                 if str(event_name).lower() in (blynk._VPIN_READ_ALL, blynk._VPIN_WRITE_ALL):
                     event_base_name = str(event_name).split(blynk._VPIN_WILDCARD)[0]
-                    for i in range(blynk.VPIN_MAX_NUM + 1):
+                    for i in range(blynk.VPIN_MAX_NUM):
                         blynk._events['{}{}'.format(event_base_name.lower(), i)] = func
                 else:
                     blynk._events[str(event_name).lower()] = func

--- a/test/test_blynk_main.py
+++ b/test/test_blynk_main.py
@@ -94,7 +94,7 @@ class TestBlynk:
             pass
 
         assert 'read v10' in bl._events.keys()
-        assert len(bl._events.keys()) == bl.VPIN_MAX_NUM
+        assert len(bl._events.keys()) == bl.VPIN_MAX_NUM + 1
 
     def test_write_wildcard_event(self, bl):
         bl._events = {}
@@ -104,7 +104,7 @@ class TestBlynk:
             pass
 
         assert 'write v5' in bl._events.keys()
-        assert len(bl._events.keys()) == bl.VPIN_MAX_NUM
+        assert len(bl._events.keys()) == bl.VPIN_MAX_NUM + 1
 
     def test_call_handler(self, bl):
         bl._events = {}


### PR DESCRIPTION
Commit 4bd673b causes read/write wildcard tests to fail, as it allows a nonexistent virtual pin 33 to be passed to a wildcard decorator.

This fixes the two wildcard tests that were failing. All passed on this branch.