### PR TITLE
Add support for redirect command

### DIFF
--- a/blynklib.py
+++ b/blynklib.py
@@ -221,11 +221,11 @@ class Connection(Protocol):
         rsp_data = self.receive(self.rcv_buffer, self.SOCK_MAX_TIMEOUT)
         if not rsp_data:
             raise BlynkError('Auth stage timeout')
-        _, _, status, args = self.parse_response(rsp_data, self.rcv_buffer)
+        msg_type, _, status, args = self.parse_response(rsp_data, self.rcv_buffer)
         if status != self.STATUS_OK:
             if status == self.STATUS_INVALID_TOKEN:
                 raise BlynkError('Invalid Auth Token')
-            if status == self.STATUS_NO_DATA:
+            if msg_type == self.MSG_REDIRECT:
                 raise RedirectError(*args)
             raise BlynkError('Auth stage failed. Status={}'.format(status))
         self._state = self.AUTHENTICATED

--- a/blynklib.py
+++ b/blynklib.py
@@ -256,8 +256,6 @@ class Blynk(Connection):
     _VPIN_READ_ALL = '{}{}'.format(_VPIN_READ, _VPIN_WILDCARD)
     _VPIN_WRITE_ALL = '{}{}'.format(_VPIN_WRITE, _VPIN_WILDCARD)
     _events = {}
-    _token = None
-    _connection_args = None
 
     def __init__(self, token, **kwargs):
         Connection.__init__(self, token, **kwargs)
@@ -266,8 +264,6 @@ class Blynk(Connection):
         self._last_send_time = ticks_ms()
         self._last_ping_time = ticks_ms()
         self._state = self.DISCONNECTED
-        self._token = token
-        self._connection_args = kwargs
         print(LOGO)
 
     def connect(self, timeout=_CONNECT_TIMEOUT):
@@ -286,10 +282,9 @@ class Blynk(Connection):
                     sleep_ms(self.TASK_PERIOD_RES)
                 except RedirectError as r_err:
                     self.disconnect()
+                    self.server = r_err.server
+                    self.port = r_err.port
                     sleep_ms(self.TASK_PERIOD_RES)
-                    self._connection_args['server'] = r_err.server
-                    self._connection_args['port'] = r_err.port
-                    Connection.__init__(self, self._token, **self._connection_args)
             if time.time() >= end_time:
                 return False
 


### PR DESCRIPTION
My Python library was failing due to unsupported command from server. Turns out it was a redirect request, that wasn't implemented yet in Python lib. Here's the implementation.