### PR TITLE
Fix reconnect spin when heartbeat fails

### DIFF
--- a/blynklib.py
+++ b/blynklib.py
@@ -248,7 +248,6 @@ class Connection(Protocol):
         self._last_rcv_time = ticks_ms()
         self._last_ping_time = 0
 
-
     def connected(self):
         return True if self._state == self.AUTHENTICATED else False
 

--- a/blynklib.py
+++ b/blynklib.py
@@ -237,6 +237,7 @@ class Connection(Protocol):
 
     def _set_heartbeat(self):
         self.send(self.heartbeat_msg(self.heartbeat, self.rcv_buffer))
+        self._last_send_time = ticks_ms()
         rcv_data = self.receive(self.rcv_buffer, self.SOCK_MAX_TIMEOUT)
         if not rcv_data:
             raise BlynkError('Heartbeat stage timeout')
@@ -244,6 +245,9 @@ class Connection(Protocol):
         if status != self.STATUS_OK:
             raise BlynkError('Set heartbeat returned code={}'.format(status))
         self.log('Heartbeat = {} sec. MaxCmdBuffer = {} bytes'.format(self.heartbeat, self.rcv_buffer))
+        self._last_rcv_time = ticks_ms()
+        self._last_ping_time = 0
+
 
     def connected(self):
         return True if self._state == self.AUTHENTICATED else False


### PR DESCRIPTION
This pull fixes a reconnect loop that happens if the heartbeat fails to be received in time.

Without this, when the library has decided it's lost the server connection, it will spin on reconnects thinking they too are dead before trying to use them.