### PR TITLE
Revert socket timeout implementation

### DIFF
--- a/blynklib_mp.py
+++ b/blynklib_mp.py
@@ -151,9 +151,12 @@ class Connection(Protocol):
         self.log = log
 
     def _set_socket_timeout(self, timeout):
-        p = select.poll()
-        p.register(self._socket)
-        p.poll(int(timeout * const(1000)))
+        if getattr(self._socket, 'settimeout', None):
+            self._socket.settimeout(timeout)
+        else:
+            p = select.poll()
+            p.register(self._socket)
+            p.poll(int(timeout * const(1000)))
 
     def send(self, data):
         retries = self.RETRIES_TX_MAX_NUM


### PR DESCRIPTION
On the TinyPICO board, the new implementation of the
_set_socket_timeout() method makes the self._socket.recv(length)
call block until the server times out and closes the socket.

This makes the device periodically reconnecting/reauthenticating
with the server as it cannot do the ping as it's supposed to.

The new implementation of _set_socket_timeout() is in line with
the usocket documentation recommendations but it seems that it
doesn't work on some boards. Well at least the TinyPICO.

Reverting to the previous _set_socket_timeout() which should
cover all cases.