### PR TITLE
Ensure millisecond precision in read_response()

### DIFF
--- a/blynklib_mp.py
+++ b/blynklib_mp.py
@@ -345,8 +345,8 @@ class Blynk(Connection):
                 self.call_handler("{}{}".format(self._VPIN_READ, msg_args[1]), int(msg_args[1]))
 
     def read_response(self, timeout=0.5):
-        end_time = time.time() + timeout
-        while time.time() <= end_time:
+        end_time = time.ticks_ms() + int(timeout * const(1000))
+        while time.ticks_diff(end_time, time.ticks_ms()) > 0:
             rsp_data = self.receive(self.rcv_buffer, self.SOCK_TIMEOUT)
             if rsp_data:
                 self._last_rcv_time = ticks_ms()


### PR DESCRIPTION
The micropython documentation for utime.time() states that on
some hardware, the function only have second precision.

This is the case at least for the TinyPICO board.

This means that we get an effective 1 second timeout for the
read_response() function instead of the expected 50ms. In turn,
it makes the run() function quite slow which delays the whole
application.

To get higher precision, the documentation recommends to use
utime.ticks_ms() instead which is what have been implemented
here.