### PR TITLE
Update blynklib.py

### DIFF
--- a/blynklib.py
+++ b/blynklib.py
@@ -64,8 +64,8 @@ class Protocol(object):
     def _get_msg_id(self, **kwargs):
         if 'msg_id' in kwargs:
             return kwargs['msg_id']
-        self._msg_id += 1
-        return self._msg_id if self._msg_id <= 0xFFFF else 0
+        self._msg_id = self._msg_id + 1 if self._msg_id < 0xFFFF else 1
+        return self._msg_id
 
     def _pack_msg(self, msg_type, *args, **kwargs):
         data = ('\0'.join([str(curr_arg) for curr_arg in args])).encode('utf-8')

--- a/blynklib.py
+++ b/blynklib.py
@@ -64,8 +64,8 @@ class Protocol(object):
     def _get_msg_id(self, **kwargs):
         if 'msg_id' in kwargs:
             return kwargs['msg_id']
-        self._msg_id = self._msg_id + 1 if self._msg_id < 0xFFFF else 1
-        return self._msg_id
+        self._msg_id += 1
+        return self._msg_id if self._msg_id <= 0xFFFF else 1
 
     def _pack_msg(self, msg_type, *args, **kwargs):
         data = ('\0'.join([str(curr_arg) for curr_arg in args])).encode('utf-8')


### PR DESCRIPTION
The hardware disconnects from the server when it reaches the value 65535 (see the log file below), this change fixed the issue, no more disconnects.

 14:51:34.477 TRACE- Incoming HardwareMessage{id=65526, command=Hardware, body='vw^@1^@25.7'}
14:51:34.482 TRACE- Incoming HardwareMessage{id=65527, command=Hardware, body='vw^@2^@40'}
14:51:35.350 TRACE- Incoming id=65528, command=Ping, body=''
14:51:35.513 TRACE- Incoming HardwareMessage{id=65529, command=Hardware, body='vw^@14^@255'}
14:51:35.539 TRACE- Incoming HardwareMessage{id=65530, command=Hardware, body='vw^@1^@25.7'}
14:51:35.543 TRACE- Incoming HardwareMessage{id=65531, command=Hardware, body='vw^@2^@40'}
14:51:36.573 TRACE- Incoming HardwareMessage{id=65532, command=Hardware, body='vw^@14^@255'}
14:51:36.597 TRACE- Incoming HardwareMessage{id=65533, command=Hardware, body='vw^@1^@25.7'}
14:51:36.601 TRACE- Incoming HardwareMessage{id=65534, command=Hardware, body='vw^@2^@40'}
14:51:37.629 TRACE- Incoming HardwareMessage{id=65535, command=Hardware, body='vw^@14^@255'}
14:51:37.654 TRACE- Incoming HardwareMessage{id=0, command=Hardware, body='vw^@1^@25.7'}
14:51:37.659 TRACE- Incoming HardwareMessage{id=0, command=Hardware, body='vw^@2^@40'}
14:51:37.875 TRACE- Incoming HardwareMessage{id=0, command=Hardware, body='vw^@4^@0'}
14:51:38.696 TRACE- Incoming HardwareMessage{id=0, command=Hardware, body='vw^@14^@255'}
14:51:38.718 TRACE- Incoming HardwareMessage{id=0, command=Hardware, body='vw^@1^@25.7'}
14:51:38.723 TRACE- Incoming HardwareMessage{id=0, command=Hardware, body='vw^@2^@40'}
14:51:39.751 TRACE- Incoming HardwareMessage{id=0, command=Hardware, body='vw^@14^@255'}
14:51:39.776 TRACE- Incoming HardwareMessage{id=0, command=Hardware, body='vw^@1^@25.6'}
14:51:39.781 TRACE- Incoming HardwareMessage{id=0, command=Hardware, body='vw^@2^@40'}
14:51:40.811 TRACE- Incoming HardwareMessage{id=0, command=Hardware, body='vw^@14^@255'}
14:51:40.836 TRACE- Incoming HardwareMessage{id=0, command=Hardware, body='vw^@1^@25.6'}
14:51:40.842 TRACE- Incoming HardwareMessage{id=0, command=Hardware, body='vw^@2^@40'}
14:51:41.871 TRACE- Incoming HardwareMessage{id=0, command=Hardware, body='vw^@14^@255'}
14:51:41.896 TRACE- Incoming HardwareMessage{id=0, command=Hardware, body='vw^@1^@25.6'}
14:51:41.902 TRACE- Incoming HardwareMessage{id=0, command=Hardware, body='vw^@2^@40'}
14:51:42.930 TRACE- Incoming HardwareMessage{id=0, command=Hardware, body='vw^@14^@255'}
14:51:42.956 TRACE- Incoming HardwareMessage{id=0, command=Hardware, body='vw^@1^@25.6'}
14:51:42.961 TRACE- Incoming HardwareMessage{id=0, command=Hardware, body='vw^@2^@40'}
14:51:43.990 TRACE- Incoming HardwareMessage{id=0, command=Hardware, body='vw^@14^@255'}
14:51:44.015 TRACE- Incoming HardwareMessage{id=0, command=Hardware, body='vw^@1^@25.6'}
14:51:44.019 TRACE- Incoming HardwareMessage{id=0, command=Hardware, body='vw^@2^@40'}
14:51:45.046 TRACE- Incoming HardwareMessage{id=0, command=Hardware, body='vw^@14^@255'}
14:51:45.068 TRACE- Incoming HardwareMessage{id=0, command=Hardware, body='vw^@1^@25.6'}
14:51:45.073 TRACE- Incoming HardwareMessage{id=0, command=Hardware, body='vw^@2^@40'}
14:51:45.435 TRACE- Incoming id=0, command=Ping, body=''
14:51:45.494 TRACE- Incoming HardwareMessage{id=0, command=Hardware, body='vw^@0^@server disconnected'}
14:51:45.505 TRACE- Hardware channel disconnect for UserKey{email='email@email.com', appName='Blynk'}, dashId 363038412, deviceId 0, token 34ANGpngMJdq1Vzc6MzjsqB37K8nmZOU.
14:51:45.507 TRACE- Changing device status. DeviceId 0, dashId 363038412
14:51:46.618 TRACE- Blynk hardware plain protocol connection detected.
14:51:46.623 TRACE- Incoming LoginMessage{id=4, command=Login, body='34ANGpngMJdq1Vzc6MzjsqB37K8nmZOU'}
14:51:46.627 DEBUG- completeLogin. [id: 0x42d222c5, L:/127.0.1.1:8080 - R:/127.0.0.1:32794]
14:51:46.639 TRACE- Connected device id 0, dash id 363038412
14:51:46.644 INFO - email@email.com hardware joined.
14:51:46.645 TRACE- Incoming id=5, command=Internal, body='ver^@0.2.6^@buff-in^@1024^@h-beat^@10^@dev^@python'
14:51:46.649 TRACE- Info command. heartbeat interval 10
14:51:46.768 DEBUG-

Request DefaultFullHttpRequest(decodeResult: success, version: HTTP/1.1, content: UnpooledSlicedByteBuf(freed))
POST /fcm/send HTTP/1.1
Authorization: key=AAAAucxWLNg:APA91bHqxju865u6rpENgdsDM0HAK6pfYr0iCpcgkzmKrLWpH-8ljrTps5467tx0Ok0ZrpmB_vUIRRVW2hjutrGgT1btT_d6WpU0RVsdfzzMSeHPwm2yXd37Lyi05H3C7Fz-7ZimilslN
content-type: application/json; charset=utf-8
content-length: 262
host: fcm.googleapis.com
accept: */*

Response DefaultHttpResponse(decodeResult: success, version: HTTP/1.1)
HTTP/1.1 200 OK
Content-Type: application/json; charset=UTF-8
Date: Wed, 11 Nov 2020 13:51:46 GMT
Expires: Wed, 11 Nov 2020 13:51:46 GMT
Cache-Control: private, max-age=0
X-Content-Type-Options: nosniff
X-Frame-Options: SAMEORIGIN
Content-Security-Policy: frame-ancestors 'self'
X-XSS-Protection: 1; mode=block
Server: GSE
Alt-Svc: h3-Q050=":443"; ma=2592000,h3-29=":443"; ma=2592000,h3-T051=":443"; ma=2592000,h3-T050=":443"; ma=2592000,h3-Q046=":443"; ma=2592000,h3-Q043=":443"; ma=2592000,quic=":443"; ma=2592000; v="46,43"
Accept-Ranges: none
Vary: Accept-Encoding
Transfer-Encoding: chunked

14:51:47.620 TRACE- Incoming HardwareMessage{id=6, command=Hardware, body='vw^@14^@255'}
14:51:47.642 TRACE- Incoming HardwareMessage{id=7, command=Hardware, body='vw^@1^@25.6'}
14:51:47.645 TRACE- Incoming HardwareMessage{id=8, command=Hardware, body='vw^@2^@40'}